### PR TITLE
fix: for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -1,4 +1,6 @@
 name: Check spelling errors
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/icco/etu-server/security/code-scanning/11](https://github.com/icco/etu-server/security/code-scanning/11)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions for this workflow or job to the minimum needed. This is done by adding a `permissions:` block either at the top level of the workflow (so it applies to all jobs) or within the `misspell` job. Since this workflow only checks out code and runs a spelling checker, the minimum safe permission is `contents: read`. If in the future the action is configured to comment on pull requests using `reviewdog`’s reporter modes, an additional scoped permission like `pull-requests: write` might be needed, but the current snippet shows no such configuration.

The single best fix, without changing existing functionality, is to add a workflow-level `permissions` block immediately after the `name:` line. This ensures the entire workflow uses least-privilege permissions and satisfies CodeQL’s recommendation. Concretely, in `.github/workflows/misspell.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Check spelling errors`). No imports or other definitions are required, as this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
