### PR TITLE
fix: Clear-text logging of sensitive information

### DIFF
--- a/lib/grpc/client.ts
+++ b/lib/grpc/client.ts
@@ -272,9 +272,9 @@ export interface VerifyApiKeyResponse {
 
 // Helper to create headers with API key
 function createHeaders(apiKey: string): HeadersInit {
-  // Debug: log API key prefix (first 10 chars) to verify it's being passed
+  // Debug: log presence of API key without exposing its value
   if (process.env.NODE_ENV !== "production") {
-    console.log(`gRPC auth header: ${apiKey ? apiKey.substring(0, 10) + "..." : "(empty)"}`)
+    console.log(`gRPC auth header configured: ${apiKey ? "present" : "absent"}`)
   }
   // Use Authorization header with the API key (backend expects raw key, not Bearer format)
   return {


### PR DESCRIPTION
Potential fix for [https://github.com/icco/etu-web/security/code-scanning/12](https://github.com/icco/etu-web/security/code-scanning/12)

In general, the fix is to ensure that sensitive authentication material (API keys) is never written to logs, even in non‑production environments. If debugging information is needed, log non‑sensitive metadata instead (for example, whether a header is set, or a generic boolean flag), or use a synthetic request identifier that is not the key itself.

For this specific snippet in `lib/grpc/client.ts`, the best change that preserves functionality is to remove the API key value from the log message entirely and replace it with a generic statement indicating whether an API key is present. Functionality of the client (sending the `Authorization` header) remains unchanged; only the debug log content changes. The minimal edit is inside `createHeaders` at lines 274–283: adjust the `console.log` call so it no longer includes `apiKey` or any substring of it. No new methods or imports are needed, as we continue to use `console.log` but with a constant or non‑sensitive message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
