### PR TITLE
docs: move to timeclimbers.com hostnames

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -66,7 +66,7 @@ export default function DocsPage() {
                 <code className="block text-sm bg-base-300 px-4 py-2 rounded whitespace-pre">
 {`{
   "api_key": "your-64-char-hex-api-key",
-  "grpc_target": "grpc.etu.natwelch.com:443"
+  "grpc_target": "grpc.etu.timeclimbers.com:443"
 }`}
                 </code>
               </div>
@@ -74,7 +74,7 @@ export default function DocsPage() {
                 <p className="text-sm font-medium mb-2">Option 2: Environment variables</p>
                 <code className="block text-sm bg-base-300 px-4 py-2 rounded">
                   export ETU_API_KEY=&quot;your-api-key&quot;<br />
-                  export ETU_GRPC_TARGET=&quot;grpc.etu.natwelch.com:443&quot;
+                  export ETU_GRPC_TARGET=&quot;grpc.etu.timeclimbers.com:443&quot;
                 </code>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Updated the only hardcoded reference to `grpc.etu.natwelch.com` in `app/docs/page.tsx` (CLI config example shown on the `/docs` page) to `grpc.etu.timeclimbers.com`.
- No other `etu.natwelch.com` / `be.etu.natwelch.com` / `grpc.etu.natwelch.com` references exist in this repo — the runtime gRPC backend URL is provided via the `GRPC_BACKEND_URL` env var (set in deployment infra, not in code).

## Scope notes
- Other `*.natwelch.com` mentions in the repo are unrelated services and were left alone: `reportd.natwelch.com` (CSP report endpoint in `next.config.ts`) and `writing.natwelch.com` (blog link in README).
- No mobile manifests, `.env` files, OAuth/Stripe config, or universal-link / app-link configuration exist in this repo.

## Flagged to confirm out-of-band (not changed here)
- **CLI users** with existing `~/.config/etu/config.json` containing `grpc.etu.natwelch.com:443` will break when DNS is cut, since the backend hosts do not redirect. The `/docs` page now shows the new hostname, but in-flight users need to update their local config manually.
- **etu-mobile** (separate repo at github.com/icco/etu-mobile) — if it hardcodes `grpc.etu.natwelch.com` or `be.etu.natwelch.com`, it needs an updated release pushed before old DNS goes away.
- **etu-backend** — confirm its CORS / allowed origins include `etu.timeclimbers.com`.
- **OAuth redirect URIs** (if etu uses GitHub/Google/etc OAuth) — provider dashboards may still list `etu.natwelch.com` callback URLs.
- **CSP `connect-src`** in `next.config.ts` currently allows `https://reportd.natwelch.com` only. If the gRPC backend's new hostname needs to be allow-listed for browser fetches, that's worth a follow-up — but the gRPC client here runs server-side (`lib/grpc/client.ts`), so likely not affected.

## Test plan
- [ ] Visit `/docs` locally and confirm the CLI config snippet shows `grpc.etu.timeclimbers.com:443` in both the JSON example and the env-var example.
- [ ] After merge + deploy, confirm `etu.timeclimbers.com/docs` renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)