### PR TITLE
fix(stripe): wire up subscription management button

### DIFF
--- a/app/(app)/settings/subscription/subscription-view.tsx
+++ b/app/(app)/settings/subscription/subscription-view.tsx
@@ -1,16 +1,60 @@
 "use client"
 
+import { useEffect, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import { format } from "date-fns"
 import { CreditCardIcon } from "@heroicons/react/24/outline"
+import { toast } from "sonner"
 
 interface SubscriptionViewProps {
   user: {
     subscriptionStatus: string
     subscriptionEnd: Date | null
+    hasStripeCustomer: boolean
   }
 }
 
 export function SubscriptionView({ user }: SubscriptionViewProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    const result = searchParams.get("subscription")
+    if (!result) return
+    if (result === "success") {
+      toast.success("Subscription updated")
+      router.refresh()
+    } else if (result === "cancelled") {
+      toast.info("Subscription change cancelled")
+    }
+    // Strip the query param so the toast doesn't re-fire on refresh
+    router.replace("/settings/subscription")
+  }, [searchParams, router])
+
+  const handleManage = async () => {
+    setIsLoading(true)
+    try {
+      const endpoint = user.hasStripeCustomer
+        ? "/api/stripe/portal"
+        : "/api/stripe/checkout"
+      const res = await fetch(endpoint, { method: "POST" })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || "Failed to open subscription")
+      }
+      const { url } = await res.json()
+      if (!url) throw new Error("No redirect URL returned")
+      window.location.href = url
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Something went wrong"
+      toast.error(message)
+      setIsLoading(false)
+    }
+  }
+
+  const buttonLabel = user.hasStripeCustomer ? "Manage Subscription" : "Subscribe"
+
   return (
     <div className="card bg-base-100 shadow-xl">
       <div className="card-body">
@@ -45,9 +89,17 @@ export function SubscriptionView({ user }: SubscriptionViewProps) {
             <span className="text-3xl font-bold">$5</span>
             <span className="text-base-content/60">/ year</span>
           </div>
-          <button className="btn btn-ghost w-full gap-2">
-            <CreditCardIcon className="h-5 w-5" />
-            Manage Subscription
+          <button
+            className="btn btn-ghost w-full gap-2"
+            onClick={handleManage}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <span className="loading loading-spinner loading-sm" />
+            ) : (
+              <CreditCardIcon className="h-5 w-5" />
+            )}
+            {buttonLabel}
           </button>
           <p className="text-xs text-base-content/60 text-center mt-2">
             Powered by Stripe

--- a/app/(app)/settings/subscription/subscription-view.tsx
+++ b/app/(app)/settings/subscription/subscription-view.tsx
@@ -25,8 +25,8 @@ export function SubscriptionView({ user }: SubscriptionViewProps) {
     if (result === "success") {
       toast.success("Subscription updated")
       router.refresh()
-    } else if (result === "cancelled") {
-      toast.info("Subscription change cancelled")
+    } else if (result === "canceled") {
+      toast.info("Subscription change canceled")
     }
     // Strip the query param so the toast doesn't re-fire on refresh
     router.replace("/settings/subscription")

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -66,8 +66,8 @@ export async function POST(request: Request) {
       payment_method_types: ["card"],
       line_items: [{ price: STRIPE_PRICE_ID, quantity: 1 }],
       mode: "subscription",
-      success_url: `${process.env.AUTH_URL}/settings?subscription=success`,
-      cancel_url: `${process.env.AUTH_URL}/settings?subscription=cancelled`,
+      success_url: `${process.env.AUTH_URL}/settings/subscription?subscription=success`,
+      cancel_url: `${process.env.AUTH_URL}/settings/subscription?subscription=cancelled`,
       metadata: { userId: user.id },
     })
 

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -14,6 +14,12 @@ function getGrpcApiKey(): string {
 }
 
 export async function POST(request: Request) {
+  const authUrl = process.env.AUTH_URL
+  if (!authUrl) {
+    logger.error("AUTH_URL environment variable is required")
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 503 })
+  }
+
   // CSRF protection: verify origin
   if (!isSameOrigin(request)) {
     logger.error({
@@ -66,8 +72,8 @@ export async function POST(request: Request) {
       payment_method_types: ["card"],
       line_items: [{ price: STRIPE_PRICE_ID, quantity: 1 }],
       mode: "subscription",
-      success_url: `${process.env.AUTH_URL}/settings/subscription?subscription=success`,
-      cancel_url: `${process.env.AUTH_URL}/settings/subscription?subscription=canceled`,
+      success_url: `${authUrl}/settings/subscription?subscription=success`,
+      cancel_url: `${authUrl}/settings/subscription?subscription=canceled`,
       metadata: { userId: user.id },
     })
 

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: Request) {
       line_items: [{ price: STRIPE_PRICE_ID, quantity: 1 }],
       mode: "subscription",
       success_url: `${process.env.AUTH_URL}/settings/subscription?subscription=success`,
-      cancel_url: `${process.env.AUTH_URL}/settings/subscription?subscription=cancelled`,
+      cancel_url: `${process.env.AUTH_URL}/settings/subscription?subscription=canceled`,
       metadata: { userId: user.id },
     })
 

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { auth } from "@/lib/auth"
 import { authService } from "@/lib/grpc/client"
-import { stripe } from "@/lib/stripe"
+import { stripe, STRIPE_PORTAL_CONFIGURATION_ID } from "@/lib/stripe"
 import { isSameOrigin } from "@/lib/security"
 import logger from "@/lib/logger"
 
@@ -57,6 +57,9 @@ export async function POST(request: Request) {
     const portalSession = await stripe.billingPortal.sessions.create({
       customer: customerId,
       return_url: `${authUrl}/settings/subscription`,
+      ...(STRIPE_PORTAL_CONFIGURATION_ID && {
+        configuration: STRIPE_PORTAL_CONFIGURATION_ID,
+      }),
     })
 
     return NextResponse.json({ url: portalSession.url })

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server"
+import { auth } from "@/lib/auth"
+import { authService } from "@/lib/grpc/client"
+import { stripe } from "@/lib/stripe"
+import { isSameOrigin } from "@/lib/security"
+import logger from "@/lib/logger"
+
+function getGrpcApiKey(): string {
+  const key = process.env.GRPC_API_KEY
+  if (!key) {
+    throw new Error("GRPC_API_KEY environment variable is required")
+  }
+  return key
+}
+
+export async function POST(request: Request) {
+  if (!isSameOrigin(request)) {
+    logger.error({
+      origin: request.headers.get("origin"),
+      referer: request.headers.get("referer"),
+    }, "Stripe portal CSRF attempt detected")
+    return NextResponse.json(
+      { error: "Invalid request origin" },
+      { status: 403 }
+    )
+  }
+
+  if (!stripe) {
+    return NextResponse.json({ error: "Stripe not configured" }, { status: 503 })
+  }
+
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  try {
+    const userResponse = await authService.getUser(
+      { userId: session.user.id },
+      getGrpcApiKey()
+    )
+    const customerId = userResponse.user.stripeCustomerId
+
+    if (!customerId) {
+      return NextResponse.json(
+        { error: "No subscription to manage" },
+        { status: 400 }
+      )
+    }
+
+    const portalSession = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: `${process.env.AUTH_URL}/settings/subscription`,
+    })
+
+    return NextResponse.json({ url: portalSession.url })
+  } catch (error) {
+    logger.error({
+      error,
+      userId: session.user.id,
+    }, "Stripe portal error")
+    return NextResponse.json({ error: "Failed to open portal" }, { status: 500 })
+  }
+}

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -14,6 +14,12 @@ function getGrpcApiKey(): string {
 }
 
 export async function POST(request: Request) {
+  const authUrl = process.env.AUTH_URL
+  if (!authUrl) {
+    logger.error("AUTH_URL environment variable is required")
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 503 })
+  }
+
   if (!isSameOrigin(request)) {
     logger.error({
       origin: request.headers.get("origin"),
@@ -50,7 +56,7 @@ export async function POST(request: Request) {
 
     const portalSession = await stripe.billingPortal.sessions.create({
       customer: customerId,
-      return_url: `${process.env.AUTH_URL}/settings/subscription`,
+      return_url: `${authUrl}/settings/subscription`,
     })
 
     return NextResponse.json({ url: portalSession.url })

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -103,6 +103,7 @@ export async function getCurrentUser() {
         ? timestampToDate(response.user.updatedAt)
         : null,
       hasNotionKey: Boolean(response.user.notionKey),
+      hasStripeCustomer: Boolean(response.user.stripeCustomerId),
     }
   } catch (error) {
     logger.error({ error }, "Get current user error")

--- a/lib/grpc/mock.ts
+++ b/lib/grpc/mock.ts
@@ -111,6 +111,7 @@ let mockUser: User = {
   email: "test@example.com",
   name: "Test User",
   subscriptionStatus: "active",
+  stripeCustomerId: "cus_mock_123",
   createdAt: mockTimestamp(new Date("2026-01-01T00:00:00Z")),
   notionKey: undefined,
 }

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -5,3 +5,5 @@ export const stripe = process.env.STRIPE_SECRET_KEY
   : null
 
 export const STRIPE_PRICE_ID = process.env.STRIPE_PRICE_ID
+export const STRIPE_PORTAL_CONFIGURATION_ID =
+  process.env.STRIPE_PORTAL_CONFIGURATION_ID

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,16 +356,16 @@
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
 "@icco/etu-proto@^2026.2.0":
-  version "2026.5.144607"
-  resolved "https://npm.pkg.github.com/download/@icco/etu-proto/2026.5.144607/10017071c356182272d30b8e569f3b449291a270#10017071c356182272d30b8e569f3b449291a270"
-  integrity sha512-rpSyCX0rCHmq7dAMag4XwWPQpc2Zo04C6lSPj+/UG2vJbjkkZj2cjKk41AjZ5tpRojXvnKGD+sHR6Fjy9EmKmg==
+  version "2026.5.212626"
+  resolved "https://npm.pkg.github.com/download/@icco/etu-proto/2026.5.212626/7108b989307bca1265a254998123b9df76e68fe4#7108b989307bca1265a254998123b9df76e68fe4"
+  integrity sha512-RWMP9wTDaj5anRp5CoKXxql/Wp3+uuXZ5tL09+w9lQmGKEZrM23dEUaHoGVwxt2C2curCVJgy5NiURNqauKr4w==
   dependencies:
     "@bufbuild/protobuf" "^2.0.0"
 
 "@icco/react-common@^2026.510.2":
-  version "2026.10510.1"
-  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.10510.1/bfa79ee2a6aef3216007a61e883a82bfe7cf30a7#bfa79ee2a6aef3216007a61e883a82bfe7cf30a7"
-  integrity sha512-I/LER85TnMCxgNhxW3imVHyNmtoNrH6ahsBBKIvyzXrCdWAVleb1mADyT9RXc0QcN6mnelvuHgs9eFESThpiZg==
+  version "2026.10513.1"
+  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.10513.1/36a4cd212fc79e3675b582804718a7124a3933c0#36a4cd212fc79e3675b582804718a7124a3933c0"
+  integrity sha512-5tgaI8oUaT1WfDNfLsanckUJl6Q/DmqOZwgwB0TRO4fClm/IaRNHL9YmEZbjYUmXScr05Y4fdsXZjSnOT2tg3g==
   dependencies:
     "@wrksz/themes" "^0.9.0"
     vivus "^0.4.6"


### PR DESCRIPTION

The **Manage Subscription** button had no onClick handler and there was no billing portal endpoint, so subscription management was broken end-to-end.

- Add `/api/stripe/portal` for Billing Portal sessions
- Wire the button to checkout (new) or portal (existing), with loading + error toast
- Expose `hasStripeCustomer` from `getCurrentUser` so the client picks the right flow
- Show toast + `router.refresh()` on return from Stripe; fix `success_url`/`cancel_url` to land on `/settings/subscription`
- Give the mock user a `stripeCustomerId` so e2e covers the active path

Requires the Stripe Customer Portal to be configured in the dashboard.

