### PR TITLE
feat(stripe): sync expanded customer + subscription data to backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,7 @@ jobs:
           locale: US
           ignore: Colour,colour
           exclude: yarn.lock
+          fail_level: any
   pr-status:
     if: github.event_name == 'pull_request' && !cancelled()
     needs:

--- a/app/(app)/settings/subscription/subscription-view.tsx
+++ b/app/(app)/settings/subscription/subscription-view.tsx
@@ -11,6 +11,7 @@ interface SubscriptionViewProps {
     subscriptionStatus: string
     subscriptionEnd: Date | null
     hasStripeCustomer: boolean
+    cancelAtPeriodEnd: boolean
   }
 }
 
@@ -76,7 +77,9 @@ export function SubscriptionView({ user }: SubscriptionViewProps) {
           </span>
           {user.subscriptionEnd && (
             <span className="text-sm text-base-content/60" suppressHydrationWarning>
-              {user.subscriptionStatus === "active" ? "Renews" : "Ends"}{" "}
+              {user.subscriptionStatus === "active" && !user.cancelAtPeriodEnd
+                ? "Renews"
+                : "Ends"}{" "}
               {format(new Date(user.subscriptionEnd), "MMMM d, yyyy")}
             </span>
           )}

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -53,6 +53,7 @@ export async function POST(request: Request) {
     if (!customerId) {
       const customer = await stripe.customers.create({
         email: user.email || undefined,
+        name: user.name || undefined,
         metadata: { userId: user.id },
       })
       customerId = customer.id
@@ -72,6 +73,8 @@ export async function POST(request: Request) {
       payment_method_types: ["card"],
       line_items: [{ price: STRIPE_PRICE_ID, quantity: 1 }],
       mode: "subscription",
+      billing_address_collection: "required",
+      customer_update: { name: "auto", address: "auto" },
       success_url: `${authUrl}/settings/subscription?subscription=success`,
       cancel_url: `${authUrl}/settings/subscription?subscription=canceled`,
       metadata: { userId: user.id },

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -12,10 +12,71 @@ function getGrpcApiKey(): string {
   return key
 }
 
-function dateToTimestamp(date: Date): Timestamp {
-  const seconds = Math.floor(date.getTime() / 1000)
-  const nanos = (date.getTime() % 1000) * 1000000
-  return { seconds: seconds.toString(), nanos }
+function unixToTimestamp(unixSeconds: number): Timestamp {
+  return { seconds: Math.floor(unixSeconds).toString(), nanos: 0 }
+}
+
+function mapSubscriptionStatus(stripeStatus: Stripe.Subscription.Status): string {
+  switch (stripeStatus) {
+    case "active":
+      return "active"
+    case "trialing":
+      return "trial"
+    case "past_due":
+      return "past_due"
+    case "canceled":
+      return "cancelled"
+    default:
+      return "inactive"
+  }
+}
+
+async function syncSubscription(subscription: Stripe.Subscription) {
+  const customerId = subscription.customer as string
+  const userResponse = await authService.getUserByStripeCustomerId(
+    { stripeCustomerId: customerId },
+    getGrpcApiKey()
+  )
+  if (!userResponse.user) return
+
+  const item = subscription.items.data[0]
+  const periodEnd = item?.current_period_end
+  const periodStart = item?.current_period_start
+  const priceId = item?.price?.id
+
+  await authService.updateUserSubscription(
+    {
+      userId: userResponse.user.id,
+      subscriptionStatus: mapSubscriptionStatus(subscription.status),
+      stripeSubscriptionId: subscription.id,
+      stripePriceId: priceId,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      subscriptionEnd: periodEnd ? unixToTimestamp(periodEnd) : undefined,
+      currentPeriodStart: periodStart ? unixToTimestamp(periodStart) : undefined,
+    },
+    getGrpcApiKey()
+  )
+}
+
+async function syncCustomerProfile(customer: Stripe.Customer) {
+  if (customer.deleted) return
+  const userId = customer.metadata?.userId
+  if (!userId) return
+
+  const address = customer.address ?? undefined
+  await authService.updateUserStripeCustomer(
+    {
+      userId,
+      name: customer.name ?? undefined,
+      billingLine1: address?.line1 ?? undefined,
+      billingLine2: address?.line2 ?? undefined,
+      billingCity: address?.city ?? undefined,
+      billingState: address?.state ?? undefined,
+      billingPostalCode: address?.postal_code ?? undefined,
+      billingCountry: address?.country ?? undefined,
+    },
+    getGrpcApiKey()
+  )
 }
 
 export async function POST(req: NextRequest) {
@@ -46,6 +107,9 @@ export async function POST(req: NextRequest) {
         const session = event.data.object as Stripe.Checkout.Session
         const userId = session.metadata?.userId
         if (userId) {
+          // Stripe will follow with customer.subscription.created which fills
+          // in price/period fields. Here we just stamp the customer id and
+          // status so the user sees a paid state immediately.
           await authService.updateUserSubscription(
             {
               userId,
@@ -60,34 +124,24 @@ export async function POST(req: NextRequest) {
 
       case "customer.subscription.updated":
       case "customer.subscription.created": {
+        await syncSubscription(event.data.object as Stripe.Subscription)
+        break
+      }
+
+      case "customer.subscription.deleted": {
         const subscription = event.data.object as Stripe.Subscription
         const customerId = subscription.customer as string
-
         const userResponse = await authService.getUserByStripeCustomerId(
           { stripeCustomerId: customerId },
           getGrpcApiKey()
         )
-
         if (userResponse.user) {
-          const status =
-            subscription.status === "active"
-              ? "active"
-              : subscription.status === "trialing"
-              ? "trial"
-              : subscription.status === "past_due"
-              ? "past_due"
-              : "inactive"
-
-          // In Stripe SDK v20+, current_period_end is on subscription items
-          const periodEnd = subscription.items.data[0]?.current_period_end
-
           await authService.updateUserSubscription(
             {
               userId: userResponse.user.id,
-              subscriptionStatus: status,
-              subscriptionEnd: periodEnd
-                ? dateToTimestamp(new Date(periodEnd * 1000))
-                : undefined,
+              subscriptionStatus: "cancelled",
+              stripeSubscriptionId: subscription.id,
+              cancelAtPeriodEnd: false,
             },
             getGrpcApiKey()
           )
@@ -98,12 +152,10 @@ export async function POST(req: NextRequest) {
       case "invoice.payment_failed": {
         const invoice = event.data.object as Stripe.Invoice
         const customerId = invoice.customer as string
-
         const userResponse = await authService.getUserByStripeCustomerId(
           { stripeCustomerId: customerId },
           getGrpcApiKey()
         )
-
         if (userResponse.user) {
           await authService.updateUserSubscription(
             {
@@ -116,20 +168,40 @@ export async function POST(req: NextRequest) {
         break
       }
 
-      case "customer.subscription.deleted": {
-        const subscription = event.data.object as Stripe.Subscription
-        const customerId = subscription.customer as string
+      case "invoice.paid":
+      case "invoice.payment_succeeded": {
+        // A successful payment can clear a past_due state. Re-sync from the
+        // subscription if one is attached to the invoice.
+        const invoice = event.data.object as Stripe.Invoice
+        const lineSub = invoice.lines?.data?.[0]?.subscription
+        const subId =
+          typeof lineSub === "string"
+            ? lineSub
+            : lineSub && "id" in lineSub
+              ? lineSub.id
+              : undefined
+        if (subId) {
+          const subscription = await stripe.subscriptions.retrieve(subId)
+          await syncSubscription(subscription)
+        }
+        break
+      }
 
-        const userResponse = await authService.getUserByStripeCustomerId(
-          { stripeCustomerId: customerId },
-          getGrpcApiKey()
-        )
+      case "customer.created":
+      case "customer.updated": {
+        await syncCustomerProfile(event.data.object as Stripe.Customer)
+        break
+      }
 
-        if (userResponse.user) {
+      case "customer.deleted": {
+        const customer = event.data.object as Stripe.Customer
+        const userId = customer.metadata?.userId
+        if (userId) {
           await authService.updateUserSubscription(
             {
-              userId: userResponse.user.id,
+              userId,
               subscriptionStatus: "cancelled",
+              cancelAtPeriodEnd: false,
             },
             getGrpcApiKey()
           )

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -25,7 +25,7 @@ function mapSubscriptionStatus(stripeStatus: Stripe.Subscription.Status): string
     case "past_due":
       return "past_due"
     case "canceled":
-      return "cancelled"
+      return "canceled"
     default:
       return "inactive"
   }
@@ -63,17 +63,20 @@ async function syncCustomerProfile(customer: Stripe.Customer) {
   const userId = customer.metadata?.userId
   if (!userId) return
 
-  const address = customer.address ?? undefined
+  // Proto contract: undefined leaves the column unchanged; "" explicitly
+  // clears it. When Stripe reports a null name or address we want the cleared
+  // state to propagate, so map null → "" rather than null → undefined.
+  const address = customer.address
   await authService.updateUserStripeCustomer(
     {
       userId,
-      name: customer.name ?? undefined,
-      billingLine1: address?.line1 ?? undefined,
-      billingLine2: address?.line2 ?? undefined,
-      billingCity: address?.city ?? undefined,
-      billingState: address?.state ?? undefined,
-      billingPostalCode: address?.postal_code ?? undefined,
-      billingCountry: address?.country ?? undefined,
+      name: customer.name ?? "",
+      billingLine1: address?.line1 ?? "",
+      billingLine2: address?.line2 ?? "",
+      billingCity: address?.city ?? "",
+      billingState: address?.state ?? "",
+      billingPostalCode: address?.postal_code ?? "",
+      billingCountry: address?.country ?? "",
     },
     getGrpcApiKey()
   )
@@ -139,7 +142,7 @@ export async function POST(req: NextRequest) {
           await authService.updateUserSubscription(
             {
               userId: userResponse.user.id,
-              subscriptionStatus: "cancelled",
+              subscriptionStatus: "canceled",
               stripeSubscriptionId: subscription.id,
               cancelAtPeriodEnd: false,
             },
@@ -195,12 +198,21 @@ export async function POST(req: NextRequest) {
 
       case "customer.deleted": {
         const customer = event.data.object as Stripe.Customer
-        const userId = customer.metadata?.userId
+        let userId: string | undefined = customer.metadata?.userId
+        if (!userId) {
+          const userResponse = await authService.getUserByStripeCustomerId(
+            { stripeCustomerId: customer.id },
+            getGrpcApiKey()
+          )
+          userId = userResponse.user?.id
+        }
         if (userId) {
           await authService.updateUserSubscription(
             {
               userId,
-              subscriptionStatus: "cancelled",
+              subscriptionStatus: "canceled",
+              // Clear the stale customer id since the Stripe record is gone.
+              stripeCustomerId: "",
               cancelAtPeriodEnd: false,
             },
             getGrpcApiKey()

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -104,6 +104,7 @@ export async function getCurrentUser() {
         : null,
       hasNotionKey: Boolean(response.user.notionKey),
       hasStripeCustomer: Boolean(response.user.stripeCustomerId),
+      cancelAtPeriodEnd: Boolean(response.user.cancelAtPeriodEnd),
     }
   } catch (error) {
     logger.error({ error }, "Get current user error")

--- a/lib/grpc/client.ts
+++ b/lib/grpc/client.ts
@@ -100,6 +100,16 @@ export interface User {
   createdAt?: Timestamp
   updatedAt?: Timestamp
   stripeCustomerId?: string
+  stripeSubscriptionId?: string
+  stripePriceId?: string
+  cancelAtPeriodEnd?: boolean
+  currentPeriodStart?: Timestamp
+  billingLine1?: string
+  billingLine2?: string
+  billingCity?: string
+  billingState?: string
+  billingPostalCode?: string
+  billingCountry?: string
   notionKey?: string
 }
 
@@ -193,6 +203,16 @@ function convertUser(user: ProtoUser | undefined): User {
     createdAt: user.createdAt ? convertTimestamp(user.createdAt) : undefined,
     updatedAt: user.updatedAt ? convertTimestamp(user.updatedAt) : undefined,
     stripeCustomerId: user.stripeCustomerId,
+    stripeSubscriptionId: user.stripeSubscriptionId,
+    stripePriceId: user.stripePriceId,
+    cancelAtPeriodEnd: user.cancelAtPeriodEnd,
+    currentPeriodStart: user.currentPeriodStart ? convertTimestamp(user.currentPeriodStart) : undefined,
+    billingLine1: user.billingLine1,
+    billingLine2: user.billingLine2,
+    billingCity: user.billingCity,
+    billingState: user.billingState,
+    billingPostalCode: user.billingPostalCode,
+    billingCountry: user.billingCountry,
     notionKey: user.notionKey,
   }
 }
@@ -447,7 +467,16 @@ const realAuthService = {
   },
 
   async updateUserSubscription(
-    request: { userId: string; subscriptionStatus: string; stripeCustomerId?: string; subscriptionEnd?: Timestamp },
+    request: {
+      userId: string
+      subscriptionStatus: string
+      stripeCustomerId?: string
+      subscriptionEnd?: Timestamp
+      stripeSubscriptionId?: string
+      stripePriceId?: string
+      cancelAtPeriodEnd?: boolean
+      currentPeriodStart?: Timestamp
+    },
     apiKey: string
   ) {
     return withErrorHandling(async () => {
@@ -463,11 +492,52 @@ const realAuthService = {
               nanos: request.subscriptionEnd.nanos,
             }
             : undefined,
+          stripeSubscriptionId: request.stripeSubscriptionId,
+          stripePriceId: request.stripePriceId,
+          cancelAtPeriodEnd: request.cancelAtPeriodEnd ?? false,
+          currentPeriodStart: request.currentPeriodStart
+            ? {
+              seconds: BigInt(request.currentPeriodStart.seconds.toString()),
+              nanos: request.currentPeriodStart.nanos,
+            }
+            : undefined,
         },
         { headers: createHeaders(apiKey) }
       )
       return { user: convertUser(response.user) }
     }, "AuthService.updateUserSubscription")
+  },
+
+  async updateUserStripeCustomer(
+    request: {
+      userId: string
+      name?: string
+      billingLine1?: string
+      billingLine2?: string
+      billingCity?: string
+      billingState?: string
+      billingPostalCode?: string
+      billingCountry?: string
+    },
+    apiKey: string
+  ) {
+    return withErrorHandling(async () => {
+      const client = getClient(AuthService)
+      const response = await client.updateUserStripeCustomer(
+        {
+          userId: request.userId,
+          name: request.name,
+          billingLine1: request.billingLine1,
+          billingLine2: request.billingLine2,
+          billingCity: request.billingCity,
+          billingState: request.billingState,
+          billingPostalCode: request.billingPostalCode,
+          billingCountry: request.billingCountry,
+        },
+        { headers: createHeaders(apiKey) }
+      )
+      return { user: convertUser(response.user) }
+    }, "AuthService.updateUserStripeCustomer")
   },
 
 }

--- a/lib/grpc/mock.ts
+++ b/lib/grpc/mock.ts
@@ -305,6 +305,24 @@ export const mockAuthService: AuthServiceApi = {
       subscriptionStatus: request.subscriptionStatus || mockUser.subscriptionStatus,
       stripeCustomerId: request.stripeCustomerId,
       subscriptionEnd: request.subscriptionEnd,
+      stripeSubscriptionId: request.stripeSubscriptionId,
+      stripePriceId: request.stripePriceId,
+      cancelAtPeriodEnd: request.cancelAtPeriodEnd,
+      currentPeriodStart: request.currentPeriodStart,
+    }
+    return { user: updatedUser }
+  },
+
+  async updateUserStripeCustomer(request, _apiKey) {
+    const updatedUser = {
+      ...mockUser,
+      name: request.name ?? mockUser.name,
+      billingLine1: request.billingLine1,
+      billingLine2: request.billingLine2,
+      billingCity: request.billingCity,
+      billingState: request.billingState,
+      billingPostalCode: request.billingPostalCode,
+      billingCountry: request.billingCountry,
     }
     return { user: updatedUser }
   },

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -351,6 +351,14 @@
                 </li>
               
                 <li>
+                  <a href="#etu.UpdateUserStripeCustomerRequest"><span class="badge">M</span>UpdateUserStripeCustomerRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#etu.UpdateUserStripeCustomerResponse"><span class="badge">M</span>UpdateUserStripeCustomerResponse</a>
+                </li>
+              
+                <li>
                   <a href="#etu.UpdateUserSubscriptionRequest"><span class="badge">M</span>UpdateUserSubscriptionRequest</a>
                 </li>
               
@@ -1861,8 +1869,105 @@
 
         
       
+        <h3 id="etu.UpdateUserStripeCustomerRequest">UpdateUserStripeCustomerRequest</h3>
+        <p>UpdateUserStripeCustomerRequest updates customer-level Stripe profile</p><p>fields (name, billing address) synced from Stripe webhook events.</p><p>All optional fields are only persisted when set; pass an empty/null value</p><p>to leave the existing column unchanged. Empty strings explicitly clear</p><p>the field.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>user_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>name is the customer&#39;s display name on the Stripe customer record. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_line1</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_line1 is the first line of the billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_line2</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_line2 is the second line of the billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_city</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_city is the city of the billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_state</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_state is the state or region of the billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_postal_code</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_postal_code is the postal code of the billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_country</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_country is the ISO-3166-1 alpha-2 country code. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="etu.UpdateUserStripeCustomerResponse">UpdateUserStripeCustomerResponse</h3>
+        <p>UpdateUserStripeCustomerResponse returns the updated user record.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>user</td>
+                  <td><a href="#etu.User">User</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
         <h3 id="etu.UpdateUserSubscriptionRequest">UpdateUserSubscriptionRequest</h3>
-        <p>UpdateUserSubscriptionRequest updates subscription billing fields.</p>
+        <p>UpdateUserSubscriptionRequest updates subscription billing fields.</p><p>Optional fields are only persisted when set; pass an empty/null value to</p><p>leave the existing column unchanged. cancel_at_period_end is always written.</p>
 
         
           <table class="field-table">
@@ -1897,6 +2002,35 @@
                   <td><a href="#google.protobuf.Timestamp">google.protobuf.Timestamp</a></td>
                   <td>optional</td>
                   <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>stripe_subscription_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>stripe_subscription_id sets the Stripe subscription resource id. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>stripe_price_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>stripe_price_id sets the Stripe price id the user is subscribed to. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>cancel_at_period_end</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>cancel_at_period_end sets whether the subscription will cancel at the
+end of the current billing period. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>current_period_start</td>
+                  <td><a href="#google.protobuf.Timestamp">google.protobuf.Timestamp</a></td>
+                  <td>optional</td>
+                  <td><p>current_period_start sets the start of the current billing period. </p></td>
                 </tr>
               
             </tbody>
@@ -2031,6 +2165,78 @@ an &lt;img src&gt;. </p></td>
                   <td><a href="#string">string</a></td>
                   <td>optional</td>
                   <td><p>notion_database_name is the Notion database used for sync. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>stripe_subscription_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>stripe_subscription_id is the Stripe subscription resource id. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>stripe_price_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>stripe_price_id is the Stripe price the user is currently subscribed to. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>cancel_at_period_end</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>cancel_at_period_end reports whether the subscription will cancel at
+the end of the current billing period. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>current_period_start</td>
+                  <td><a href="#google.protobuf.Timestamp">google.protobuf.Timestamp</a></td>
+                  <td>optional</td>
+                  <td><p>current_period_start is the start of the current billing period. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_line1</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_line1 is the first line of the user&#39;s billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_line2</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_line2 is the second line of the user&#39;s billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_city</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_city is the city of the user&#39;s billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_state</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_state is the state or region of the user&#39;s billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_postal_code</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_postal_code is the postal code of the user&#39;s billing address. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>billing_country</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>billing_country is the ISO-3166-1 alpha-2 country code of the
+user&#39;s billing address. </p></td>
                 </tr>
               
             </tbody>
@@ -2229,6 +2435,14 @@ an &lt;img src&gt;. </p></td>
                 <td><a href="#etu.UpdateUserSubscriptionRequest">UpdateUserSubscriptionRequest</a></td>
                 <td><a href="#etu.UpdateUserSubscriptionResponse">UpdateUserSubscriptionResponse</a></td>
                 <td><p>UpdateUserSubscription updates billing-related subscription state.</p></td>
+              </tr>
+            
+              <tr>
+                <td>UpdateUserStripeCustomer</td>
+                <td><a href="#etu.UpdateUserStripeCustomerRequest">UpdateUserStripeCustomerRequest</a></td>
+                <td><a href="#etu.UpdateUserStripeCustomerResponse">UpdateUserStripeCustomerResponse</a></td>
+                <td><p>UpdateUserStripeCustomer syncs Stripe customer profile fields
+(name, billing address) from Stripe webhook events.</p></td>
               </tr>
             
           </tbody>

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,9 +302,9 @@
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
 "@icco/etu-proto@^2026.2.0":
-  version "2026.5.14022123"
-  resolved "https://npm.pkg.github.com/download/@icco/etu-proto/2026.5.14022123/07ed0190611a52c1852dacce252d333b5b4fb50f#07ed0190611a52c1852dacce252d333b5b4fb50f"
-  integrity sha512-gurS3X4McI6ovjT18wzAbUes79odI0YGw5f8ni2d2ygvdd2rdonKe4oNO2JavynZpBjt/vkiQvgW1DxqMCDrkA==
+  version "2026.5.14030617"
+  resolved "https://npm.pkg.github.com/download/@icco/etu-proto/2026.5.14030617/630ac386e6921da342c9e189fe30c68a7e55948a#630ac386e6921da342c9e189fe30c68a7e55948a"
+  integrity sha512-wPGVEVbgZeHWlwHC7wUB4WeZcdlvZWcQfbwFICQKDd4ZRDxdjtH/ckEbssvNMqQ+0m2zknffUaZA4R/dBRWVxg==
   dependencies:
     "@bufbuild/protobuf" "^2.0.0"
 


### PR DESCRIPTION
## Summary

Companion to [icco/etu-backend#83](https://github.com/icco/etu-backend/pull/83). Marked draft because TypeScript will not compile until \`@icco/etu-proto\` republishes with the new fields and RPC (auto-publishes when the backend PR merges to main).

**Outbound to Stripe**
- Pass user \`name\` when creating Stripe customers
- Enable \`billing_address_collection: "required"\` in Checkout so the address lands on the customer

**Inbound from Stripe webhooks**
- \`customer.subscription.*\`: now also persists \`subscription_id\`, \`price_id\`, \`cancel_at_period_end\`, \`current_period_start\`
- \`invoice.paid\` / \`invoice.payment_succeeded\`: re-sync from the subscription so a successful payment clears \`past_due\`
- \`customer.created\` / \`customer.updated\`: new — sync name + billing address back via \`UpdateUserStripeCustomer\`
- \`customer.deleted\`: new — mark cancelled

**UI**
- Subscription page shows "Ends" instead of "Renews" when the user has cancelled but still has access (\`cancelAtPeriodEnd\`)

## To finalize before merging

After etu-backend#83 lands and \`@icco/etu-proto\` auto-publishes:
1. \`yarn install\` to bump the lockfile
2. \`yarn lint\` (tsc) should pass
3. Mark this PR ready for review

## Test plan
- [ ] \`yarn lint\` passes after proto bump
- [ ] Trigger a test subscription create in Stripe test mode; confirm sub_id, price_id, period_start are stored
- [ ] Cancel-at-period-end; confirm UI shows "Ends $date"
- [ ] Update billing address in Stripe portal; confirm webhook syncs the fields back

🤖 Generated with [Claude Code](https://claude.com/claude-code)